### PR TITLE
Add doctrine/data-fixtures dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.*",
+        "doctrine/data-fixtures": "dev-master",
         "doctrine/doctrine-orm-module": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
After [this commit](https://github.com/doctrine/DoctrineModule/commit/bb4bc8898b914b1eee510ed8d714bac4d88c3fc3) DoctrineModule no longer depends of doctrine/data-fixtures. But we still depend :)
