### PR TITLE
Move loadCli.post to module init from bootstrap

### DIFF
--- a/src/DoctrineDataFixtureModule/Module.php
+++ b/src/DoctrineDataFixtureModule/Module.php
@@ -19,19 +19,12 @@
 
 namespace DoctrineDataFixtureModule;
 
-
-use Zend\ModuleManager\ModuleManagerInterface;
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
-use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\Feature\ServiceProviderInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\Loader\AutoloaderFactory;
-use Zend\Loader\StandardAutoloader;
 use Zend\EventManager\EventInterface;
-
+use Zend\ModuleManager\ModuleManager;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
-
 use DoctrineDataFixtureModule\Command\ImportCommand;
 use DoctrineDataFixtureModule\Service\FixtureFactory;
 
@@ -44,7 +37,6 @@ use DoctrineDataFixtureModule\Service\FixtureFactory;
  */
 class Module implements
     AutoloaderProviderInterface,
-    BootstrapListenerInterface,
     ServiceProviderInterface,
     ConfigProviderInterface
 {
@@ -65,14 +57,9 @@ class Module implements
     /**
      * {@inheritDoc}
      */
-    public function onBootstrap(EventInterface $e)
+    public function init(ModuleManager $e)
     {
-        //$config = $app->getServiceManager()->get('Config');
-        //$app->getServiceManager()->get('doctrine.configuration.fixtures');
-
-        /* @var $app \Zend\Mvc\ApplicationInterface */
-        $app    = $e->getTarget();
-        $events = $app->getEventManager()->getSharedManager();
+        $events = $e->getEventManager()->getSharedManager();
 
         // Attach to helper set event and load the entity manager helper.
         $events->attach('doctrine', 'loadCli.post', function(EventInterface $e) {


### PR DESCRIPTION
In the latest 0.8.x Doctrine release it's required to register the loadCli.post event in the init.
