### PR TITLE
Reduce doctrine-orm-module depenence to rely on dependencies through dat...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.*",
         "doctrine/data-fixtures": "dev-master",
-        "doctrine/doctrine-orm-module": "*"
+        "doctrine/doctrine-orm-module": "~0.7"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
...a-fixtures rather than requiring dev-master

I'm writing an ORM + ODM app with these dependencies which cannot resolve with the dev-master require for orm-module from DoctrineDataFixtureModule.

By changing to "*" it lets dependencies waterfall from doctrine/data-fixtures

```
    "php": ">=5.4",
    "zendframework/zendframework": ">2.1",

    "doctrine/common": "2.3.x-dev",
    "doctrine/dbal": "2.3.x-dev",
    "doctrine/orm": "2.3.x-dev",
    "doctrine/migrations": "v1.0-ALPHA1",
    "doctrine/doctrine-module": "0.7.2",
    "doctrine/doctrine-orm-module": "0.7.0",
    "doctrine/doctrine-mongo-odm-module": "0.8.*@dev",
    "doctrine/data-fixtures": "dev-master",
    "hounddog/doctrine-data-fixture-module": "dev-master",
```
