### PR TITLE
Change "dev-master" to "@dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "zendframework/zend-modulemanager": "2.*",
         "zendframework/zend-eventmanager": "2.*",
         "zendframework/zend-servicemanager": "2.*",
-        "doctrine/data-fixtures": "dev-master",
+        "doctrine/data-fixtures": "@dev",
         "doctrine/doctrine-orm-module": "~0.7"
     },
     "autoload": {


### PR DESCRIPTION
The case here is "dev-master" requires composer to set the minimum stability to dev for your whole project. This will sometimes load, although you have specified versions, also dev versions from other libraries.

The `@dev` syntax means only `doctrine/data-fixtures` is loaded as master from git, all other dependencies remain intact.
