### PR TITLE
Update Module.php

### DIFF
--- a/src/DoctrineDataFixtureModule/Module.php
+++ b/src/DoctrineDataFixtureModule/Module.php
@@ -69,8 +69,10 @@ class Module implements
             /* @var $sm ServiceLocatorInterface */
             $sm = $e->getParam('ServiceManager');
             $em = $cli->getHelperSet()->get('em')->getEntityManager();
-            $paths = $sm->get('doctrine.configuration.fixtures');
-
+            //$paths = $sm->get('doctrine.configuration.fixtures');
+            $config = $sm->get('Config');
+            $paths = $config['doctrine']['configuration']['fixtures'];
+            
             $importCommand = new ImportCommand($sm);
             $importCommand->setEntityManager($em);
             $importCommand->setPath($paths);


### PR DESCRIPTION
I tried to use your module with zf 2.3.2dev and when I execute the import command the module delete all my data but, doesn't create anything, that because the command:
$paths = $sm->get('doctrine.configuration.fixtures');
in Module.php doesn't work.
Just change it with:
$config = $sm->get('Config'); $paths = $config['doctrine']['configuration']['fixtures'];
and please change the documentation for the reference of fixture paths.
