### PR TITLE
Removed initializing of default Doctrine commands

### DIFF
--- a/src/DoctrineDataFixtureModule/Module.php
+++ b/src/DoctrineDataFixtureModule/Module.php
@@ -74,7 +74,6 @@ class Module implements
             $importCommand = new ImportCommand($sm);
             $importCommand->setEntityManager($em);
             $importCommand->setPath($paths);
-            ConsoleRunner::addCommands($cli);
             $cli->addCommands(array(
                 $importCommand
             ));


### PR DESCRIPTION
Correct me if i'm wrong, but there was initialization of default set of doctrine commands. It is not required here because module don't make console calls to any of this commands, and it will break configured custom commands.
